### PR TITLE
CI-1: add iOS build & test workflow

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,23 @@
+name: iOS CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: Build
+        run: xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build
+      - name: Test
+        run: |
+          if [ -d FairSplitTests ] || [ -d FairSplitUITests ]; then
+            xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1
+          else
+            echo "No tests found, skipping."
+          fi

--- a/FairSplit.xcodeproj/xcshareddata/xcschemes/FairSplit.xcscheme
+++ b/FairSplit.xcodeproj/xcshareddata/xcschemes/FairSplit.xcscheme
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion="1640"
+   version="1.3">
+   <BuildAction parallelizeBuildables="NO" buildImplicitDependencies="YES">
+      <BuildActionEntries>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="28AC09792E5AA732002A301A"
+               BuildableName="FairSplit.app"
+               BlueprintName="FairSplit"
+               ReferencedContainer="container:FairSplit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
+      <Testables>
+         <TestableReference skipped="NO">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="28AC09882E5AA733002A301A"
+               BuildableName="FairSplitTests.xctest"
+               BlueprintName="FairSplitTests"
+               ReferencedContainer="container:FairSplit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference skipped="NO">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="28AC09922E5AA733002A301A"
+               BuildableName="FairSplitUITests.xctest"
+               BlueprintName="FairSplitUITests"
+               ReferencedContainer="container:FairSplit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="28AC09792E5AA732002A301A"
+            BuildableName="FairSplit.app"
+            BlueprintName="FairSplit"
+            ReferencedContainer="container:FairSplit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="28AC09792E5AA732002A301A"
+            BuildableName="FairSplit.app"
+            BlueprintName="FairSplit"
+            ReferencedContainer="container:FairSplit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="28AC09792E5AA732002A301A"
+            BuildableName="FairSplit.app"
+            BlueprintName="FairSplit"
+            ReferencedContainer="container:FairSplit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction buildConfiguration="Release" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="28AC09792E5AA732002A301A"
+            BuildableName="FairSplit.app"
+            BlueprintName="FairSplit"
+            ReferencedContainer="container:FairSplit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration="Debug">
+   </AnalyzeAction>
+   <ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # FairSplit
+[![iOS CI](https://github.com/OWNER/FairSplit/actions/workflows/ios-ci.yml/badge.svg)](https://github.com/OWNER/FairSplit/actions/workflows/ios-ci.yml)
 
 A lightweight SwiftUI app scaffold for splitting expenses among participants. This repository is structured for clarity and quick iteration, with Models, Views, Helpers, and tests organized per AGENTS.md.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test the FairSplit iOS app
- share the FairSplit scheme so CI can locate it
- show CI status badge in the README

## Testing
- `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa93b9e3548326855dfd5ec10a526c