### PR TITLE
DOC-1: Use GitHub CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FairSplit
-[![iOS CI](https://github.com/OWNER/FairSplit/actions/workflows/ios-ci.yml/badge.svg)](https://github.com/OWNER/FairSplit/actions/workflows/ios-ci.yml)
+[![iOS CI](https://github.com/shaun-stanley/FairSplit/actions/workflows/ios-ci.yml/badge.svg)](https://github.com/shaun-stanley/FairSplit/actions/workflows/ios-ci.yml)
 
 A lightweight SwiftUI app scaffold for splitting expenses among participants. This repository is structured for clarity and quick iteration, with Models, Views, Helpers, and tests organized per AGENTS.md.
 

--- a/plan.md
+++ b/plan.md
@@ -15,13 +15,16 @@
 
 ## Next Up (top first — keep ≤3)
 1. [MVP-3] Settle Up: suggest transfers and record a Settlement entry
+2. [CORE-1] Groups list polish: “You owe / You’re owed” summary, search, sort by recent activity
+3. [MATH-1] Balances helper (greedy “who pays whom”), rounded to 2 decimals
 
 ## In Progress
-[MVP-3] Settle Up: suggest transfers and record a Settlement entry
+(none)
 
 ## Done
 [MVP-1] Added SwiftData and a demo group
 [MVP-2] Polished amount input with currency formatting and validation
+[DOC-1] Use GitHub CI badge in README
 
 ## Blocked
 (none)
@@ -106,6 +109,7 @@
 ## Changelog
 - 2025-08-24: MVP-1 — Added SwiftData persistence and seeded a demo group (Alex, Sam, Kai) on first launch.
 - 2025-08-24: MVP-2 — Amount field uses locale-aware currency formatting and blocks invalid/empty values; lists and summary now show group currency.
+- 2025-08-24: DOC-1 — Updated README with CI badge.
 
 ## Vision
 A tiny, beautiful, Apple-grade Splitwise-style app for tracking shared expenses with clarity and grace.


### PR DESCRIPTION
## Summary
- point README badge to the shaun-stanley repo
- log the documentation update in PLAN.md and queue next tasks

## Testing
- `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` (fails: command not found: xcodebuild)
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` (fails: command not found: xcodebuild)

------
https://chatgpt.com/codex/tasks/task_e_68aa9947e5b48326b9ec07fc20a38694