### PR TITLE
MVP-3: add settle up view

### DIFF
--- a/FairSplit/Views/SplitSummaryView.swift
+++ b/FairSplit/Views/SplitSummaryView.swift
@@ -15,6 +15,13 @@ struct SplitSummaryView: View {
             }
         }
         .navigationTitle("Summary")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                NavigationLink("Settle Up") {
+                    SettleUpView(group: group)
+                }
+            }
+        }
     }
 }
 

--- a/FairSplitTests/DataRepositoryTests.swift
+++ b/FairSplitTests/DataRepositoryTests.swift
@@ -1,0 +1,29 @@
+import SwiftData
+import Testing
+@testable import FairSplit
+
+@MainActor
+struct DataRepositoryTests {
+    @Test
+    func recordSettlements_savesEntries() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: [Group.self, Member.self, Expense.self, Settlement.self], configurations: config)
+        let context = container.mainContext
+        let repo = DataRepository(context: context)
+
+        let a = Member(name: "A")
+        let b = Member(name: "B")
+        let group = Group(name: "Trip", defaultCurrency: "USD", members: [a, b])
+        context.insert(group)
+        try context.save()
+
+        repo.recordSettlements(for: group, transfers: [(from: a, to: b, amount: 10)])
+
+        #expect(group.settlements.count == 1)
+        let s = group.settlements.first
+        #expect(s?.from === a)
+        #expect(s?.to === b)
+        #expect(s?.amount == 10)
+    }
+}
+

--- a/FairSplitTests/SplitCalculatorTests.swift
+++ b/FairSplitTests/SplitCalculatorTests.swift
@@ -25,4 +25,24 @@ struct SplitCalculatorTests {
         #expect(net[a.persistentModelID] == Decimal(string: "6.00"))
         #expect(net[b.persistentModelID] == Decimal(string: "-6.00"))
     }
+
+    @Test
+    func proposedTransfers_matchesDebtsToCredits() {
+        let a = Member(name: "A")
+        let b = Member(name: "B")
+        let c = Member(name: "C")
+        let net: [PersistentIdentifier: Decimal] = [
+            a.persistentModelID: 5,
+            b.persistentModelID: -3,
+            c.persistentModelID: -2
+        ]
+        let transfers = SplitCalculator.proposedTransfers(netBalances: net, members: [a, b, c])
+        #expect(transfers.count == 2)
+        #expect(transfers[0].from == b)
+        #expect(transfers[0].to == a)
+        #expect(transfers[0].amount == 3)
+        #expect(transfers[1].from == c)
+        #expect(transfers[1].to == a)
+        #expect(transfers[1].amount == 2)
+    }
 }

--- a/plan.md
+++ b/plan.md
@@ -14,9 +14,9 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [MVP-3] Settle Up: suggest transfers and record a Settlement entry
-2. [CORE-1] Groups list polish: “You owe / You’re owed” summary, search, sort by recent activity
-3. [MATH-1] Balances helper (greedy “who pays whom”), rounded to 2 decimals
+1. [CORE-1] Groups list polish: “You owe / You’re owed” summary, search, sort by recent activity
+2. [MATH-1] Balances helper (greedy “who pays whom”), rounded to 2 decimals
+3. [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
 
 ## In Progress
 (none)
@@ -27,7 +27,7 @@
 [DOC-1] Use GitHub CI badge in README
 
 ## Blocked
-(none)
+[MVP-3] Settle Up: suggest transfers and record a Settlement entry — missing `xcodebuild`; install Xcode CLI tools (`xcode-select --install`) and rerun `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build`
 
 ---
 
@@ -35,7 +35,6 @@
 
 ### Core Experience
 - [CORE-1] Groups list polish: “You owe / You’re owed” summary, search, sort by recent activity
-- [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
 - [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
 - [CORE-4] Expense editing: edit/delete, swipe actions, context menu
 - [CORE-5] Categories & notes: optional category (Food/Travel/etc.) + free-text notes


### PR DESCRIPTION
## Summary
- add Settle Up navigation from summary screen
- test transfer suggestions and settlement persistence
- update planning doc; build blocked by missing `xcodebuild`

## Testing
- `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a20f12c8326a9cbf12b013035d4