### PR TITLE
CORE-1: polish groups list with balance summary and search

### DIFF
--- a/FairSplit/ContentView.swift
+++ b/FairSplit/ContentView.swift
@@ -10,25 +10,10 @@ import SwiftData
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: [SortDescriptor<Group>(\Group.name)]) private var groups: [Group]
-
-    // Provide an explicit initializer to avoid memberwise init that expects 'groups' parameter
-    init(groups _: [Group] = []) {}
 
     var body: some View {
-        let group = groups.first
-        TabView {
-            NavigationStack {
-                if let group { ExpenseListView(group: group) }
-                else { Text("Seeding data...") }
-            }
-            .tabItem { Label("Expenses", systemImage: "list.bullet") }
-
-            NavigationStack {
-                if let group { SplitSummaryView(group: group) }
-                else { Text("Seeding data...") }
-            }
-            .tabItem { Label("Summary", systemImage: "person.3.sequence") }
+        NavigationStack {
+            GroupListView()
         }
         .task {
             DataRepository(context: modelContext).seedIfNeeded()

--- a/FairSplit/Models/Group.swift
+++ b/FairSplit/Models/Group.swift
@@ -17,3 +17,22 @@ final class Group {
         self.settlements = settlements
     }
 }
+
+extension Group {
+    /// Latest activity date from expenses or settlements.
+    var lastActivity: Date {
+        let expenseDate = expenses.map(\.date).max() ?? .distantPast
+        let settlementDate = settlements.map(\.date).max() ?? .distantPast
+        return max(expenseDate, settlementDate)
+    }
+
+    /// Net balance for a member: positive means they are owed money.
+    func balance(for member: Member) -> Decimal {
+        let net = SplitCalculator.netBalances(
+            expenses: expenses,
+            members: members,
+            settlements: settlements
+        )
+        return net[member.persistentModelID] ?? 0
+    }
+}

--- a/FairSplit/Views/GroupDetailView.swift
+++ b/FairSplit/Views/GroupDetailView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import SwiftData
+
+struct GroupDetailView: View {
+    let group: Group
+
+    var body: some View {
+        TabView {
+            ExpenseListView(group: group)
+                .tabItem { Label("Expenses", systemImage: "list.bullet") }
+            SplitSummaryView(group: group)
+                .tabItem { Label("Summary", systemImage: "person.3.sequence") }
+        }
+    }
+}
+
+#Preview {
+    if let container = try? ModelContainer(
+        for: Group.self, Member.self, Expense.self, Settlement.self,
+        configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    ) {
+        let member = Member(name: "A")
+        let group = Group(name: "G", defaultCurrency: "USD", members: [member])
+        return GroupDetailView(group: group).modelContainer(container)
+    } else {
+        return Text("Preview unavailable")
+    }
+}

--- a/FairSplit/Views/GroupListView.swift
+++ b/FairSplit/Views/GroupListView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import SwiftData
+
+struct GroupListView: View {
+    @Query private var groups: [Group]
+    @State private var searchText = ""
+
+    private var filteredGroups: [Group] {
+        let filtered = groups.filter { searchText.isEmpty || $0.name.localizedCaseInsensitiveContains(searchText) }
+        return filtered.sorted { $0.lastActivity > $1.lastActivity }
+    }
+
+    var body: some View {
+        List(filteredGroups) { group in
+            NavigationLink(destination: GroupDetailView(group: group)) {
+                VStack(alignment: .leading) {
+                    Text(group.name)
+                    if let me = group.members.first {
+                        let balance = group.balance(for: me)
+                        if balance > 0 {
+                            Text("You're owed \(balance.formatted(.currency(code: group.defaultCurrency)))")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        } else if balance < 0 {
+                            Text("You owe \((-balance).formatted(.currency(code: group.defaultCurrency)))")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("All settled")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .searchable(text: $searchText)
+        .navigationTitle("Groups")
+    }
+}
+
+#Preview {
+    GroupListView()
+        .modelContainer(for: [Group.self, Member.self, Expense.self, Settlement.self], inMemory: true)
+}

--- a/FairSplitTests/GroupTests.swift
+++ b/FairSplitTests/GroupTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Testing
+@testable import FairSplit
+
+struct GroupTests {
+    @Test
+    func lastActivity_usesMostRecentDate() {
+        let m = Member(name: "A")
+        let g = Group(name: "G", defaultCurrency: "USD", members: [m])
+        let old = Expense(title: "Old", amount: 1, payer: m, participants: [m], date: .distantPast)
+        let new = Expense(title: "New", amount: 1, payer: m, participants: [m], date: .distantFuture)
+        g.expenses.append(old)
+        g.expenses.append(new)
+        #expect(g.lastActivity == .distantFuture)
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -14,9 +14,8 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [CORE-1] Groups list polish: “You owe / You’re owed” summary, search, sort by recent activity
-2. [MATH-1] Balances helper (greedy “who pays whom”), rounded to 2 decimals
-3. [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
+1. [MATH-1] Balances helper (greedy “who pays whom”), rounded to 2 decimals
+2. [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
 
 ## In Progress
 (none)
@@ -26,6 +25,7 @@
 [MVP-2] Polished amount input with currency formatting and validation
 [DOC-1] Use GitHub CI badge in README
 [MVP-3] Settle Up suggests transfers and saves them
+[CORE-1] Groups list shows balance summary, search, and recent activity sorting
 
 ## Blocked
 (none)
@@ -35,7 +35,6 @@
 ## Backlog (move items up to “Next Up” when ready)
 
 ### Core Experience
-- [CORE-1] Groups list polish: “You owe / You’re owed” summary, search, sort by recent activity
 - [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
 - [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
 - [CORE-4] Expense editing: edit/delete, swipe actions, context menu
@@ -112,6 +111,7 @@
 - 2025-08-24: MVP-2 — Amount field uses locale-aware currency formatting and blocks invalid/empty values; lists and summary now show group currency.
 - 2025-08-24: DOC-1 — Updated README with CI badge.
 - 2025-08-24: MVP-3 — Added Settle Up screen with suggested transfers and settlement history.
+- 2025-08-24: CORE-1 — Groups list shows balance summary, search, and recent activity sorting.
 
 ## Vision
 A tiny, beautiful, Apple-grade Splitwise-style app for tracking shared expenses with clarity and grace.


### PR DESCRIPTION
## Summary
- list all groups with recent activity sorting and search
- show per-group "You owe/You're owed" balance summary
- refactor content view to use new group list and add basic unit test

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68aaa0b0842883269ffeb18a3763ce84