### PR TITLE
MATH-1 add balances helper

### DIFF
--- a/FairSplit/Helpers/SplitCalculator.swift
+++ b/FairSplit/Helpers/SplitCalculator.swift
@@ -81,4 +81,11 @@ enum SplitCalculator {
         }
         return results
     }
+
+    /// Convenience helper to compute greedy settlement transfers for a group.
+    /// - Returns: Array of (from, to, amount) tuples; amounts rounded to cents.
+    static func balances(for group: Group) -> [(from: Member, to: Member, amount: Decimal)] {
+        let net = netBalances(expenses: group.expenses, members: group.members, settlements: group.settlements)
+        return proposedTransfers(netBalances: net, members: group.members)
+    }
 }

--- a/FairSplit/Views/SettleUpView.swift
+++ b/FairSplit/Views/SettleUpView.swift
@@ -6,12 +6,8 @@ struct SettleUpView: View {
     var group: Group
     @State private var saved = false
 
-    private var net: [PersistentIdentifier: Decimal] {
-        SplitCalculator.netBalances(expenses: group.expenses, members: group.members, settlements: group.settlements)
-    }
-
     private var proposals: [(from: Member, to: Member, amount: Decimal)] {
-        SplitCalculator.proposedTransfers(netBalances: net, members: group.members)
+        SplitCalculator.balances(for: group)
     }
 
     var body: some View {

--- a/FairSplitTests/SplitCalculatorTests.swift
+++ b/FairSplitTests/SplitCalculatorTests.swift
@@ -39,4 +39,17 @@ struct SplitCalculatorTests {
         #expect(transfers.contains { $0.from === b && $0.to === a && $0.amount == Decimal(string: "10.00") })
         #expect(transfers.contains { $0.from === c && $0.to === a && $0.amount == Decimal(string: "10.00") })
     }
+
+    @Test
+    func balances_forGroup_returnsRoundedTransfers() {
+        let a = Member(name: "A")
+        let b = Member(name: "B")
+        let c = Member(name: "C")
+        let exp = Expense(title: "Meal", amount: 10.00, payer: a, participants: [a, b, c])
+        let g = Group(name: "G", defaultCurrency: "USD", members: [a, b, c], expenses: [exp])
+        let transfers = SplitCalculator.balances(for: g)
+        #expect(transfers.count == 2)
+        #expect(transfers.contains { $0.from === b && $0.to === a && $0.amount == Decimal(string: "3.33") })
+        #expect(transfers.contains { $0.from === c && $0.to === a && $0.amount == Decimal(string: "3.33") })
+    }
 }

--- a/plan.md
+++ b/plan.md
@@ -14,8 +14,9 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [MATH-1] Balances helper (greedy “who pays whom”), rounded to 2 decimals
-2. [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
+1. [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
+2. [MATH-2] Unequal splits: shares / percentages / exact amounts (choose one simple mode first)
+3. [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
 
 ## In Progress
 (none)
@@ -26,6 +27,7 @@
 [DOC-1] Use GitHub CI badge in README
 [MVP-3] Settle Up suggests transfers and saves them
 [CORE-1] Groups list shows balance summary, search, and recent activity sorting
+[MATH-1] Added balances helper suggesting who pays whom
 
 ## Blocked
 (none)
@@ -45,7 +47,6 @@
 - [CORE-9] App theming: light/dark with accent color; respect system appearance
 
 ### Money & Math
-- [MATH-1] Balances helper (greedy “who pays whom”), rounded to 2 decimals
 - [MATH-2] Unequal splits: shares / percentages / exact amounts (choose one simple mode first)
 - [MATH-3] Recurring expenses (monthly rent, subscriptions) with auto-add and pause
 - [MATH-4] Multi-currency per group with **manual FX rates** (safe, offline). Optional: remember last rate used
@@ -112,6 +113,7 @@
 - 2025-08-24: DOC-1 — Updated README with CI badge.
 - 2025-08-24: MVP-3 — Added Settle Up screen with suggested transfers and settlement history.
 - 2025-08-24: CORE-1 — Groups list shows balance summary, search, and recent activity sorting.
+- 2025-08-24: MATH-1 — Added balances helper that suggests who pays whom.
 
 ## Vision
 A tiny, beautiful, Apple-grade Splitwise-style app for tracking shared expenses with clarity and grace.


### PR DESCRIPTION
## Summary
- add `SplitCalculator.balances(for:)` to compute who pays whom
- use balances helper in `SettleUpView`
- test helper rounding for group transfers
- update project plan

## Testing
- rely on GitHub Actions


------
https://chatgpt.com/codex/tasks/task_e_68aaa218a0388326917a7fc1ef59ca74