### PR TITLE
CORE-2: group detail sections

### DIFF
--- a/FairSplit/Views/GroupDetailView.swift
+++ b/FairSplit/Views/GroupDetailView.swift
@@ -4,13 +4,69 @@ import SwiftData
 struct GroupDetailView: View {
     let group: Group
 
+    private var settlementProposals: [(from: Member, to: Member, amount: Decimal)] {
+        SplitCalculator.balances(for: group)
+    }
+
     var body: some View {
-        TabView {
-            ExpenseListView(group: group)
-                .tabItem { Label("Expenses", systemImage: "list.bullet") }
-            SplitSummaryView(group: group)
-                .tabItem { Label("Summary", systemImage: "person.3.sequence") }
+        List {
+            Section("Expenses") {
+                ForEach(group.expenses, id: \.persistentModelID) { expense in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(expense.title).font(.headline)
+                            if let payer = expense.payer {
+                                Text("Paid by \(payer.name)")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        Text(CurrencyFormatter.string(from: expense.amount, currencyCode: group.defaultCurrency))
+                            .fontWeight(.semibold)
+                    }
+                }
+            }
+
+            Section("Balances") {
+                let net = SplitCalculator.netBalances(expenses: group.expenses, members: group.members, settlements: group.settlements)
+                ForEach(group.members, id: \.persistentModelID) { member in
+                    let amount = net[member.persistentModelID] ?? 0
+                    HStack {
+                        Text(member.name)
+                        Spacer()
+                        Text(CurrencyFormatter.string(from: amount, currencyCode: group.defaultCurrency))
+                            .foregroundStyle(amount >= 0 ? .green : .red)
+                    }
+                }
+            }
+
+            Section("Settle Up") {
+                if settlementProposals.isEmpty {
+                    ContentUnavailableView("You're all settled!", systemImage: "checkmark.seal")
+                } else {
+                    ForEach(Array(settlementProposals.enumerated()), id: \.offset) { _, item in
+                        HStack {
+                            Text(item.from.name)
+                            Image(systemName: "arrow.right")
+                                .foregroundStyle(.secondary)
+                            Text(item.to.name)
+                            Spacer()
+                            Text(CurrencyFormatter.string(from: item.amount, currencyCode: group.defaultCurrency))
+                                .fontWeight(.semibold)
+                        }
+                        .accessibilityLabel("\(item.from.name) pays \(item.to.name) \(CurrencyFormatter.string(from: item.amount, currencyCode: group.defaultCurrency))")
+                    }
+                }
+            }
+
+            Section("Members") {
+                ForEach(group.members, id: \.persistentModelID) { member in
+                    Text(member.name)
+                }
+            }
         }
+        .navigationTitle(group.name)
     }
 }
 

--- a/FairSplitUITests/FairSplitUITests.swift
+++ b/FairSplitUITests/FairSplitUITests.swift
@@ -30,6 +30,17 @@ final class FairSplitUITests: XCTestCase {
     }
 
     @MainActor
+    func testGroupDetail_hasSections() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.cells.first?.tap()
+        XCTAssertTrue(app.staticTexts["Expenses"].exists)
+        XCTAssertTrue(app.staticTexts["Balances"].exists)
+        XCTAssertTrue(app.staticTexts["Settle Up"].exists)
+        XCTAssertTrue(app.staticTexts["Members"].exists)
+    }
+
+    @MainActor
     func testLaunchPerformance() throws {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {

--- a/plan.md
+++ b/plan.md
@@ -14,9 +14,9 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
-2. [MATH-2] Unequal splits: shares / percentages / exact amounts (choose one simple mode first)
-3. [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
+1. [MATH-2] Unequal splits: shares / percentages / exact amounts (choose one simple mode first)
+2. [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
+3. [CORE-4] Expense editing: edit/delete, swipe actions, context menu
 
 ## In Progress
 (none)
@@ -28,6 +28,7 @@
 [MVP-3] Settle Up suggests transfers and saves them
 [CORE-1] Groups list shows balance summary, search, and recent activity sorting
 [MATH-1] Added balances helper suggesting who pays whom
+[CORE-2] Group detail shows sections for expenses, balances, settle up, and members
 
 ## Blocked
 (none)
@@ -114,6 +115,7 @@
 - 2025-08-24: MVP-3 — Added Settle Up screen with suggested transfers and settlement history.
 - 2025-08-24: CORE-1 — Groups list shows balance summary, search, and recent activity sorting.
 - 2025-08-24: MATH-1 — Added balances helper that suggests who pays whom.
+- 2025-08-24: CORE-2 — Group detail shows sections for expenses, balances, settle up, and members.
 
 ## Vision
 A tiny, beautiful, Apple-grade Splitwise-style app for tracking shared expenses with clarity and grace.


### PR DESCRIPTION
## Summary
- show group details in a single list with sticky sections for expenses, balances, settle up, and members
- add UI test coverage for the new sections
- update plan with completion and next steps

## Testing
- ⚠️ `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(not run: Xcode unavailable in container; rely on CI)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa4b7cf1083269f70dc1f86e4437d