### PR TITLE
CORE-2: add group detail sections view

### DIFF
--- a/FairSplit/Views/GroupDetailView.swift
+++ b/FairSplit/Views/GroupDetailView.swift
@@ -5,12 +5,51 @@ struct GroupDetailView: View {
     let group: Group
 
     var body: some View {
-        TabView {
-            ExpenseListView(group: group)
-                .tabItem { Label("Expenses", systemImage: "list.bullet") }
-            SplitSummaryView(group: group)
-                .tabItem { Label("Summary", systemImage: "person.3.sequence") }
+        ScrollView {
+            LazyVStack(alignment: .leading, pinnedViews: [.sectionHeaders]) {
+                Section(
+                    header: Text("Expenses")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.background)
+                ) {
+                    ExpenseListView(group: group)
+                }
+
+                Section(
+                    header: Text("Balances")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.background)
+                ) {
+                    SplitSummaryView(group: group)
+                }
+
+                Section(
+                    header: Text("Settle Up")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.background)
+                ) {
+                    SettleUpView(group: group)
+                }
+
+                Section(
+                    header: Text("Members")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.background)
+                ) {
+                    ForEach(group.members, id: \.persistentModelID) { member in
+                        Text(member.name)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 4)
+                    }
+                }
+            }
+            .padding(.horizontal)
         }
+        .navigationTitle(group.name)
     }
 }
 

--- a/FairSplitTests/GroupDetailViewTests.swift
+++ b/FairSplitTests/GroupDetailViewTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import FairSplit
+
+struct GroupDetailViewTests {
+    @Test
+    func init_usesProvidedGroup() {
+        let group = Group(name: "G", defaultCurrency: "USD")
+        let view = GroupDetailView(group: group)
+        #expect(view.group === group)
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -14,9 +14,9 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
-2. [MATH-2] Unequal splits: shares / percentages / exact amounts (choose one simple mode first)
-3. [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
+1. [MATH-2] Unequal splits: shares / percentages / exact amounts (choose one simple mode first)
+2. [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
+3. [UX-1] Dynamic Type everywhere; ensure layouts adapt up to Extra Large sizes
 
 ## In Progress
 (none)
@@ -30,7 +30,7 @@
 [MATH-1] Added balances helper suggesting who pays whom
 
 ## Blocked
-(none)
+[CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers — `xcodebuild` missing. Run `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` on macOS with Xcode installed.
 
 ---
 


### PR DESCRIPTION
## Summary
- show group details in scrollable sections for expenses, balances, settle up, and members
- add smoke test for `GroupDetailView`
- update plan to note `xcodebuild` missing

## Testing
- `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa5c780a0832691f77e6d2d61d31a