### PR TITLE
CORE-3: add member management

### DIFF
--- a/FairSplit/Helpers/DataRepository.swift
+++ b/FairSplit/Helpers/DataRepository.swift
@@ -40,4 +40,27 @@ final class DataRepository {
         }
         try? context.save()
     }
+    func addMember(to group: Group, name: String) {
+        let member = Member(name: name)
+        group.members.append(member)
+        try? context.save()
+    }
+
+    func rename(member: Member, to newName: String) {
+        member.name = newName
+        try? context.save()
+    }
+
+    /// Returns true if deletion succeeded; false if member is used in any expense.
+    func delete(member: Member, from group: Group) -> Bool {
+        let used = group.expenses.contains {
+            $0.payer?.persistentModelID == member.persistentModelID ||
+            $0.participants.contains(where: { $0.persistentModelID == member.persistentModelID })
+        }
+        guard !used else { return false }
+        context.delete(member)
+        try? context.save()
+        return true
+    }
+
 }

--- a/FairSplit/Views/GroupDetailView.swift
+++ b/FairSplit/Views/GroupDetailView.swift
@@ -61,8 +61,12 @@ struct GroupDetailView: View {
             }
 
             Section("Members") {
-                ForEach(group.members, id: \.persistentModelID) { member in
-                    Text(member.name)
+                NavigationLink(destination: MembersView(group: group)) {
+                    HStack {
+                        Text("Members")
+                        Spacer()
+                        Text("\(group.members.count)").foregroundStyle(.secondary)
+                    }
                 }
             }
         }

--- a/FairSplit/Views/MembersView.swift
+++ b/FairSplit/Views/MembersView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import SwiftData
+
+struct MembersView: View {
+    @Environment(\.modelContext) private var modelContext
+    let group: Group
+
+    @State private var showingAdd = false
+    @State private var newName = ""
+    @State private var renaming: Member?
+    @State private var renameText = ""
+    @State private var alertMessage: String?
+
+    var body: some View {
+        List {
+            ForEach(group.members, id: \.persistentModelID) { member in
+                Text(member.name)
+                    .swipeActions {
+                        Button("Rename") {
+                            renaming = member
+                            renameText = member.name
+                        }.tint(.blue)
+                        Button("Delete", role: .destructive) {
+                            let ok = DataRepository(context: modelContext).delete(member: member, from: group)
+                            if !ok { alertMessage = "This member is used in expenses and cannot be deleted." }
+                        }
+                    }
+            }
+        }
+        .navigationTitle("Members")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Add") { showingAdd = true }
+            }
+        }
+        .sheet(isPresented: $showingAdd) {
+            NavigationStack {
+                Form { TextField("Name", text: $newName) }
+                .navigationTitle("New Member")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) { Button("Cancel") { showingAdd = false; newName = "" } }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return }
+                            DataRepository(context: modelContext).addMember(to: group, name: trimmed)
+                            showingAdd = false
+                            newName = ""
+                        }.disabled(newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+        }
+        .sheet(item: $renaming) { member in
+            NavigationStack {
+                Form { TextField("Name", text: $renameText) }
+                .navigationTitle("Rename Member")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) { Button("Cancel") { renaming = nil } }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return }
+                            DataRepository(context: modelContext).rename(member: member, to: trimmed)
+                            renaming = nil
+                        }.disabled(renameText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+        }
+        .alert("Cannot Delete Member", isPresented: Binding(get: { alertMessage != nil }, set: { if !$0 { alertMessage = nil } })) {
+            Button("OK", role: .cancel) { alertMessage = nil }
+        } message: {
+            Text(alertMessage ?? "")
+        }
+    }
+}
+
+#Preview {
+    let m1 = Member(name: "Alex")
+    let group = Group(name: "Trip", defaultCurrency: "USD", members: [m1])
+    return NavigationStack { MembersView(group: group) }
+}

--- a/FairSplitTests/MemberManagementTests.swift
+++ b/FairSplitTests/MemberManagementTests.swift
@@ -1,0 +1,36 @@
+import SwiftData
+import Testing
+@testable import FairSplit
+
+struct MemberManagementTests {
+    @Test
+    func deleteMember_preventRemovalWhenReferenced() throws {
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let context = ModelContext(container)
+        let repo = DataRepository(context: context)
+        let alex = Member(name: "Alex")
+        let sam = Member(name: "Sam")
+        let group = Group(name: "Trip", defaultCurrency: "USD", members: [alex, sam])
+        let expense = Expense(title: "Lunch", amount: 20, payer: alex, participants: [alex, sam])
+        group.expenses.append(expense)
+        context.insert(group)
+        try context.save()
+        let success = repo.delete(member: alex, from: group)
+        #expect(success == false)
+        #expect(group.members.contains(alex))
+    }
+
+    @Test
+    func deleteMember_removesWhenUnused() throws {
+        let container = try ModelContainer(for: Group.self, Member.self)
+        let context = ModelContext(container)
+        let repo = DataRepository(context: context)
+        let alex = Member(name: "Alex")
+        let group = Group(name: "Trip", defaultCurrency: "USD", members: [alex])
+        context.insert(group)
+        try context.save()
+        let success = repo.delete(member: alex, from: group)
+        #expect(success == true)
+        #expect(!group.members.contains(alex))
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -14,9 +14,9 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
-2. [CORE-4] Expense editing: edit/delete, swipe actions, context menu
-3. [TEST-1] Unit tests for settlement math (edge cases, rounding, settlements)
+1. [CORE-4] Expense editing: edit/delete, swipe actions, context menu
+2. [TEST-1] Unit tests for settlement math (edge cases, rounding, settlements)
+3. [CORE-5] Categories & notes: optional category (Food/Travel/etc.) + free-text notes
 
 ## In Progress
 (none)
@@ -30,6 +30,7 @@
 [MATH-1] Added balances helper suggesting who pays whom
 [CORE-2] Group detail shows sections for expenses, balances, settle up, and members
 [MATH-2] Unequal splits allow weighted shares
+[CORE-3] Members can be added, renamed, and removed; expenses prevent deletion
 
 ## Blocked
 (none)
@@ -40,7 +41,6 @@
 
 ### Core Experience
 - [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
-- [CORE-3] Members management: add/rename/remove members; prevent deleting a member referenced by expenses
 - [CORE-4] Expense editing: edit/delete, swipe actions, context menu
 - [CORE-5] Categories & notes: optional category (Food/Travel/etc.) + free-text notes
 - [CORE-6] Attach receipts: add photo/scan using **VisionKit** document scanner; show thumbnail in expense row
@@ -116,6 +116,7 @@
 - 2025-08-24: MATH-1 — Added balances helper that suggests who pays whom.
 - 2025-08-24: CORE-2 — Group detail shows sections for expenses, balances, settle up, and members.
 - 2025-08-24: MATH-2 — Added share-based uneven splits.
+- 2025-08-24: CORE-3 — Members can be added, renamed, and removed; expenses prevent deletion.
 
 ## Vision
 A tiny, beautiful, Apple-grade Splitwise-style app for tracking shared expenses with clarity and grace.


### PR DESCRIPTION
## Summary
- allow adding, renaming, and removing group members
- block deleting members linked to expenses
- document progress in plan and changelog

## Testing
- `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa8c063d483269a02f55640a196aa