### PR TITLE
CORE-4: add swipe editing to expense list

### DIFF
--- a/FairSplit/Views/ExpenseListView.swift
+++ b/FairSplit/Views/ExpenseListView.swift
@@ -5,6 +5,7 @@ struct ExpenseListView: View {
     @Environment(\.modelContext) private var modelContext
     var group: Group
     @State private var showingAdd = false
+    @State private var editingExpense: Expense?
 
     var body: some View {
         List {
@@ -32,6 +33,18 @@ struct ExpenseListView: View {
                     Text(CurrencyFormatter.string(from: expense.amount, currencyCode: group.defaultCurrency))
                         .fontWeight(.semibold)
                 }
+                .swipeActions {
+                    Button("Edit") { editingExpense = expense }.tint(.blue)
+                    Button("Delete", role: .destructive) {
+                        DataRepository(context: modelContext).delete(expenses: [expense])
+                    }
+                }
+                .contextMenu {
+                    Button("Edit") { editingExpense = expense }
+                    Button("Delete", role: .destructive) {
+                        DataRepository(context: modelContext).delete(expenses: [expense])
+                    }
+                }
             }
             .onDelete(perform: delete)
         }
@@ -46,6 +59,13 @@ struct ExpenseListView: View {
             NavigationStack {
                 AddExpenseView(members: group.members, currencyCode: group.defaultCurrency) { title, amount, payer, included, category, note in
                     DataRepository(context: modelContext).addExpense(to: group, title: title, amount: amount, payer: payer, participants: included, category: category, note: note)
+                }
+            }
+        }
+        .sheet(item: $editingExpense) { expense in
+            NavigationStack {
+                AddExpenseView(members: group.members, currencyCode: group.defaultCurrency, expense: expense) { title, amount, payer, included, category, note in
+                    DataRepository(context: modelContext).update(expense: expense, title: title, amount: amount, payer: payer, participants: included, category: category, note: note)
                 }
             }
         }

--- a/plan.md
+++ b/plan.md
@@ -14,10 +14,8 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [CORE-4] Expense editing: edit/delete, swipe actions, context menu
-2. [TEST-2] UI tests for add/edit/delete expense and settle flow
-3. [CORE-6] Attach receipts: add photo/scan using **VisionKit** document scanner; show thumbnail in expense row
-
+1. [TEST-2] UI tests for add/edit/delete expense and settle flow
+2. [CORE-6] Attach receipts: add photo/scan using **VisionKit** document scanner; show thumbnail in expense row
 
 ## In Progress
 (none)
@@ -35,6 +33,7 @@
 [CORE-4] Expenses can be added, edited, or removed
 [TEST-1] Added unit tests for settlement math
 [CORE-5] Expenses support categories and notes
+[CORE-4] Expense list supports swipe edit and delete with context menu
 
 
 ## Blocked
@@ -46,7 +45,6 @@
 
 ### Core Experience
  - [CORE-2] Group detail: sections (Expenses, Balances, Settle Up, Members) with sticky headers
- - [CORE-4] Expense editing: edit/delete, swipe actions, context menu
  - [CORE-7] Search expenses: title, note, amount range, member filters
 - [CORE-8] Undo/Redo for create/edit/delete operations
 - [CORE-9] App theming: light/dark with accent color; respect system appearance
@@ -123,6 +121,7 @@
 - 2025-08-24: CORE-4 — Expenses can be added, edited, or removed.
 - 2025-08-24: TEST-1 — Added unit tests for settlement calculations.
 - 2025-08-24: CORE-5 — Added optional category and note fields to expenses.
+- 2025-08-24: CORE-4 — Expense list supports swipe edit and delete actions with context menu.
 
 
 ## Vision


### PR DESCRIPTION
## Summary
- add swipe actions and context menu to edit or delete expenses
- track completion in PLAN.md

## Testing
- `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab5f53c6083269745f6c4c1f3ab7b