### PR TITLE
MATH-4 add multi-currency expense fields

### DIFF
--- a/FairSplit/Models/Group.swift
+++ b/FairSplit/Models/Group.swift
@@ -31,7 +31,8 @@ extension Group {
         let net = SplitCalculator.netBalances(
             expenses: expenses,
             members: members,
-            settlements: settlements
+            settlements: settlements,
+            defaultCurrency: defaultCurrency
         )
         return net[member.persistentModelID] ?? 0
     }

--- a/FairSplit/Views/ExpenseListView.swift
+++ b/FairSplit/Views/ExpenseListView.swift
@@ -93,15 +93,15 @@ struct ExpenseListView: View {
         .searchable(text: $searchText, prompt: "Search expenses")
         .sheet(isPresented: $showingAdd) {
             NavigationStack {
-                AddExpenseView(members: group.members, currencyCode: group.defaultCurrency) { title, amount, payer, included, category, note, receipt in
-                    DataRepository(context: modelContext, undoManager: undoManager).addExpense(to: group, title: title, amount: amount, payer: payer, participants: included, category: category, note: note, receiptImageData: receipt)
+                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency) { title, amount, currency, rate, payer, included, category, note, receipt in
+                    DataRepository(context: modelContext, undoManager: undoManager).addExpense(to: group, title: title, amount: amount, payer: payer, participants: included, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
                 }
             }
         }
         .sheet(item: $editingExpense) { expense in
             NavigationStack {
-                AddExpenseView(members: group.members, currencyCode: group.defaultCurrency, expense: expense) { title, amount, payer, included, category, note, receipt in
-                    DataRepository(context: modelContext, undoManager: undoManager).update(expense: expense, title: title, amount: amount, payer: payer, participants: included, category: category, note: note, receiptImageData: receipt)
+                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency, expense: expense) { title, amount, currency, rate, payer, included, category, note, receipt in
+                    DataRepository(context: modelContext, undoManager: undoManager).update(expense: expense, title: title, amount: amount, payer: payer, participants: included, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
                 }
             }
         }

--- a/FairSplit/Views/GroupDetailView.swift
+++ b/FairSplit/Views/GroupDetailView.swift
@@ -160,15 +160,15 @@ struct GroupDetailView: View {
         .searchable(text: $searchText, prompt: "Search expenses")
         .sheet(isPresented: $showingAddExpense) {
             NavigationStack {
-                AddExpenseView(members: group.members, currencyCode: group.defaultCurrency) { title, amount, payer, participants, category, note, receipt in
-                    DataRepository(context: modelContext, undoManager: undoManager).addExpense(to: group, title: title, amount: amount, payer: payer, participants: participants, category: category, note: note, receiptImageData: receipt)
+                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency) { title, amount, currency, rate, payer, participants, category, note, receipt in
+                    DataRepository(context: modelContext, undoManager: undoManager).addExpense(to: group, title: title, amount: amount, payer: payer, participants: participants, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
                 }
             }
         }
         .sheet(item: $editingExpense) { expense in
             NavigationStack {
-                AddExpenseView(members: group.members, currencyCode: group.defaultCurrency, expense: expense) { title, amount, payer, participants, category, note, receipt in
-                    DataRepository(context: modelContext, undoManager: undoManager).update(expense: expense, title: title, amount: amount, payer: payer, participants: participants, category: category, note: note, receiptImageData: receipt)
+                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency, expense: expense) { title, amount, currency, rate, payer, participants, category, note, receipt in
+                    DataRepository(context: modelContext, undoManager: undoManager).update(expense: expense, title: title, amount: amount, payer: payer, participants: participants, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
                 }
             }
         }

--- a/FairSplit/Views/SplitSummaryView.swift
+++ b/FairSplit/Views/SplitSummaryView.swift
@@ -4,7 +4,7 @@ struct SplitSummaryView: View {
     var group: Group
 
     var body: some View {
-        let balances = SplitCalculator.netBalances(expenses: group.expenses, members: group.members, settlements: group.settlements)
+        let balances = SplitCalculator.netBalances(expenses: group.expenses, members: group.members, settlements: group.settlements, defaultCurrency: group.defaultCurrency)
         List(group.members, id: \.persistentModelID) { m in
             let amount = balances[m.persistentModelID] ?? 0
             HStack {

--- a/FairSplitTests/SplitCalculatorTests.swift
+++ b/FairSplitTests/SplitCalculatorTests.swift
@@ -20,7 +20,7 @@ struct SplitCalculatorTests {
         let a = Member(name: "A")
         let b = Member(name: "B")
         let exp = Expense(title: "Lunch", amount: 12.00, payer: a, participants: [a, b])
-        let net = SplitCalculator.netBalances(expenses: [exp], members: [a, b])
+        let net = SplitCalculator.netBalances(expenses: [exp], members: [a, b], defaultCurrency: "USD")
         // A paid 12, owes 6 => +6; B owes 6 => -6
         #expect(net[a.persistentModelID] == Decimal(string: "6.00"))
         #expect(net[b.persistentModelID] == Decimal(string: "-6.00"))
@@ -32,7 +32,7 @@ struct SplitCalculatorTests {
         let b = Member(name: "B")
         let c = Member(name: "C")
         let exp = Expense(title: "Meal", amount: 30.00, payer: a, participants: [a, b, c])
-        let net = SplitCalculator.netBalances(expenses: [exp], members: [a, b, c])
+        let net = SplitCalculator.netBalances(expenses: [exp], members: [a, b, c], defaultCurrency: "USD")
         let transfers = SplitCalculator.proposedTransfers(netBalances: net, members: [a, b, c])
         #expect(transfers.count == 2)
         // B and C each owe A ten
@@ -71,7 +71,7 @@ struct SplitCalculatorTests {
         let shareA = ExpenseShare(member: a, weight: 2)
         let shareB = ExpenseShare(member: b, weight: 1)
         let exp = Expense(title: "Taxi", amount: 30.00, payer: a, participants: [a, b], shares: [shareA, shareB])
-        let net = SplitCalculator.netBalances(expenses: [exp], members: [a, b])
+        let net = SplitCalculator.netBalances(expenses: [exp], members: [a, b], defaultCurrency: "USD")
         #expect(net[a.persistentModelID] == Decimal(string: "10.00"))
         #expect(net[b.persistentModelID] == Decimal(string: "-10.00"))
     }
@@ -82,7 +82,7 @@ struct SplitCalculatorTests {
         let b = Member(name: "B")
         let exp = Expense(title: "Dinner", amount: 20.00, payer: a, participants: [a, b])
         let settlement = Settlement(from: b, to: a, amount: 5.00)
-        let net = SplitCalculator.netBalances(expenses: [exp], members: [a, b], settlements: [settlement])
+        let net = SplitCalculator.netBalances(expenses: [exp], members: [a, b], settlements: [settlement], defaultCurrency: "USD")
         #expect(net[a.persistentModelID] == Decimal(string: "5.00"))
         #expect(net[b.persistentModelID] == Decimal(string: "-5.00"))
     }

--- a/plan.md
+++ b/plan.md
@@ -15,11 +15,11 @@
 
 ## Next Up (top first — keep ≤3)
 1. [CORE-8] Undo/Redo for create/edit/delete operations
-2. [CORE-9] App theming: light/dark with accent color; respect system appearance
-3. [UX-6] Polish primary actions placement (Add Expense, Settle Up)
+2. [DATA-3] Import/Export: CSV export for a group; CSV import for expenses (document picker)
+3. [SHARE-1] Share sheet: export a readable group summary (PDF/Markdown)
 
 ## In Progress
-[UX-6] Polish primary actions placement (Add Expense, Settle Up)
+[MATH-4] Multi-currency per group with **manual FX rates** (safe, offline). Optional: remember last rate used
 
 ## Done
 [MVP-1] Added SwiftData and a demo group
@@ -39,6 +39,7 @@
 [CORE-6] Attach receipts: add photo/scan using VisionKit; show thumbnail in list
 [TEST-4] UI tests for add/delete expense and settle up flow
 [CORE-7] Search expenses: title, note, amount range, member filters
+[UX-6] Polish primary actions placement (Add Expense, Settle Up)
 
 
 ## Blocked
@@ -129,6 +130,7 @@
 - 2025-08-25: CORE-6 — Attach receipts with VisionKit scanner and thumbnails in lists.
 - 2025-08-25: TEST-4 — UI tests for add/delete expense and settle up flow.
 - 2025-08-25: CORE-7 — Added expense search by text, amount range, and members.
+- 2025-08-26: UX-6 — Polished primary actions placement.
 
 
 ## Vision


### PR DESCRIPTION
## Summary
- track expense currency and manual FX rate in AddExpenseView
- convert expenses to group currency in lists and balances
- outline multi-currency work in PLAN.md

## Testing
- `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acacc09fb08326bc4b2c1b6560c9b7