### PR TITLE
MATH-4 remember last FX rate per currency

### DIFF
--- a/FairSplit/Models/Group.swift
+++ b/FairSplit/Models/Group.swift
@@ -5,6 +5,7 @@ import SwiftData
 final class Group {
     var name: String
     var defaultCurrency: String
+    @Attribute var lastFXRates: [String: Decimal] = [:]
     @Relationship(deleteRule: .cascade) var members: [Member]
     @Relationship(deleteRule: .cascade) var expenses: [Expense]
     @Relationship(deleteRule: .cascade) var settlements: [Settlement]

--- a/FairSplit/Views/ExpenseListView.swift
+++ b/FairSplit/Views/ExpenseListView.swift
@@ -93,15 +93,15 @@ struct ExpenseListView: View {
         .searchable(text: $searchText, prompt: "Search expenses")
         .sheet(isPresented: $showingAdd) {
             NavigationStack {
-                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency) { title, amount, currency, rate, payer, included, category, note, receipt in
+                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency, lastRates: group.lastFXRates) { title, amount, currency, rate, payer, included, category, note, receipt in
                     DataRepository(context: modelContext, undoManager: undoManager).addExpense(to: group, title: title, amount: amount, payer: payer, participants: included, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
                 }
             }
         }
         .sheet(item: $editingExpense) { expense in
             NavigationStack {
-                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency, expense: expense) { title, amount, currency, rate, payer, included, category, note, receipt in
-                    DataRepository(context: modelContext, undoManager: undoManager).update(expense: expense, title: title, amount: amount, payer: payer, participants: included, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
+                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency, expense: expense, lastRates: group.lastFXRates) { title, amount, currency, rate, payer, included, category, note, receipt in
+                    DataRepository(context: modelContext, undoManager: undoManager).update(expense: expense, in: group, title: title, amount: amount, payer: payer, participants: included, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
                 }
             }
         }

--- a/FairSplit/Views/GroupDetailView.swift
+++ b/FairSplit/Views/GroupDetailView.swift
@@ -160,15 +160,15 @@ struct GroupDetailView: View {
         .searchable(text: $searchText, prompt: "Search expenses")
         .sheet(isPresented: $showingAddExpense) {
             NavigationStack {
-                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency) { title, amount, currency, rate, payer, participants, category, note, receipt in
+                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency, lastRates: group.lastFXRates) { title, amount, currency, rate, payer, participants, category, note, receipt in
                     DataRepository(context: modelContext, undoManager: undoManager).addExpense(to: group, title: title, amount: amount, payer: payer, participants: participants, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
                 }
             }
         }
         .sheet(item: $editingExpense) { expense in
             NavigationStack {
-                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency, expense: expense) { title, amount, currency, rate, payer, participants, category, note, receipt in
-                    DataRepository(context: modelContext, undoManager: undoManager).update(expense: expense, title: title, amount: amount, payer: payer, participants: participants, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
+                AddExpenseView(members: group.members, groupCurrencyCode: group.defaultCurrency, expense: expense, lastRates: group.lastFXRates) { title, amount, currency, rate, payer, participants, category, note, receipt in
+                    DataRepository(context: modelContext, undoManager: undoManager).update(expense: expense, in: group, title: title, amount: amount, payer: payer, participants: participants, category: category, note: note, receiptImageData: receipt, currencyCode: currency, fxRateToGroupCurrency: rate)
                 }
             }
         }

--- a/FairSplitTests/ExpenseEditingTests.swift
+++ b/FairSplitTests/ExpenseEditingTests.swift
@@ -16,7 +16,7 @@ struct ExpenseEditingTests {
         context.insert(group)
         try context.save()
 
-        repo.update(expense: expense, title: "Dinner", amount: 25, payer: sam, participants: [alex, sam], category: .food, note: "Tapas")
+        repo.update(expense: expense, in: group, title: "Dinner", amount: 25, payer: sam, participants: [alex, sam], category: .food, note: "Tapas")
 
         #expect(expense.title == "Dinner")
         #expect(expense.amount == 25)

--- a/FairSplitTests/FxRateMemoryTests.swift
+++ b/FairSplitTests/FxRateMemoryTests.swift
@@ -1,0 +1,37 @@
+import SwiftData
+import Testing
+@testable import FairSplit
+
+struct FxRateMemoryTests {
+    @Test
+    func addExpense_updatesLastRate() throws {
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let context = ModelContext(container)
+        let repo = DataRepository(context: context)
+        let alex = Member(name: "Alex")
+        let group = Group(name: "Trip", defaultCurrency: "USD", members: [alex])
+        context.insert(group)
+        try context.save()
+
+        repo.addExpense(to: group, title: "Coffee", amount: 3, payer: alex, participants: [alex], currencyCode: "EUR", fxRateToGroupCurrency: 1.1)
+
+        #expect(group.lastFXRates["EUR"] == 1.1)
+    }
+
+    @Test
+    func updateExpense_updatesLastRate() throws {
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let context = ModelContext(container)
+        let repo = DataRepository(context: context)
+        let alex = Member(name: "Alex")
+        let group = Group(name: "Trip", defaultCurrency: "USD", members: [alex])
+        let expense = Expense(title: "Coffee", amount: 3, currencyCode: "EUR", fxRateToGroupCurrency: 1.1, payer: alex, participants: [alex])
+        group.expenses.append(expense)
+        context.insert(group)
+        try context.save()
+
+        repo.update(expense: expense, in: group, title: "Coffee", amount: 3, payer: alex, participants: [alex], category: nil, note: nil, currencyCode: "EUR", fxRateToGroupCurrency: 1.2)
+
+        #expect(group.lastFXRates["EUR"] == 1.2)
+    }
+}

--- a/FairSplitTests/ReceiptAttachmentTests.swift
+++ b/FairSplitTests/ReceiptAttachmentTests.swift
@@ -33,7 +33,7 @@ struct ReceiptAttachmentTests {
         try context.save()
 
         let newReceipt = Data([0x0A, 0x0B])
-        repo.update(expense: e, title: "Lunch", amount: 10, payer: alex, participants: [alex], category: nil, note: nil, receiptImageData: newReceipt)
+        repo.update(expense: e, in: group, title: "Lunch", amount: 10, payer: alex, participants: [alex], category: nil, note: nil, receiptImageData: newReceipt)
 
         #expect(e.receiptImageData == newReceipt)
     }

--- a/FairSplitTests/UndoRedoTests.swift
+++ b/FairSplitTests/UndoRedoTests.swift
@@ -33,7 +33,7 @@ struct UndoRedoTests {
         context.insert(g)
         try context.save()
 
-        repo.update(expense: e, title: "Latte", amount: 4, payer: a, participants: [a], category: nil, note: "test")
+        repo.update(expense: e, in: g, title: "Latte", amount: 4, payer: a, participants: [a], category: nil, note: "test")
         #expect(e.title == "Latte")
         undo.undo()
         #expect(e.title == "Coffee")

--- a/plan.md
+++ b/plan.md
@@ -14,12 +14,12 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [CORE-8] Undo/Redo for create/edit/delete operations
-2. [DATA-3] Import/Export: CSV export for a group; CSV import for expenses (document picker)
-3. [SHARE-1] Share sheet: export a readable group summary (PDF/Markdown)
+1. [DATA-3] Import/Export: CSV export for a group; CSV import for expenses (document picker)
+2. [SHARE-1] Share sheet: export a readable group summary (PDF/Markdown)
+3. [MATH-5] Per-member totals and per-category totals in group
 
 ## In Progress
-[MATH-4] Multi-currency per group with **manual FX rates** (safe, offline). Optional: remember last rate used
+[CORE-8] Undo/Redo for create/edit/delete operations
 
 ## Done
 [MVP-1] Added SwiftData and a demo group
@@ -40,6 +40,7 @@
 [TEST-4] UI tests for add/delete expense and settle up flow
 [CORE-7] Search expenses: title, note, amount range, member filters
 [UX-6] Polish primary actions placement (Add Expense, Settle Up)
+[MATH-4] Expenses remember last used FX rate per currency
 
 
 ## Blocked
@@ -131,6 +132,7 @@
 - 2025-08-25: TEST-4 — UI tests for add/delete expense and settle up flow.
 - 2025-08-25: CORE-7 — Added expense search by text, amount range, and members.
 - 2025-08-26: UX-6 — Polished primary actions placement.
+- 2025-08-26: MATH-4 — Expenses remember last FX rate per currency.
 
 
 ## Vision


### PR DESCRIPTION
## Summary
- persist last FX rates per currency on Group
- prefill Add Expense currency rate from prior entries and update rate on save
- cover FX rate memory with unit tests

## Testing
- No tests run (rely on GitHub Actions)


------
https://chatgpt.com/codex/tasks/task_e_68acb115fe5c83269d36b52dc6c24fbc