### PR TITLE
Fix group creation visibility by including Settlement model

### DIFF
--- a/FairSplit/ContentView.swift
+++ b/FairSplit/ContentView.swift
@@ -23,5 +23,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
-        .modelContainer(for: [Group.self, Member.self, Expense.self], inMemory: true)
+        .modelContainer(for: [Group.self, Member.self, Expense.self, Settlement.self], inMemory: true)
 }

--- a/FairSplit/FairSplitApp.swift
+++ b/FairSplit/FairSplitApp.swift
@@ -14,6 +14,6 @@ struct FairSplitApp: App {
         WindowGroup {
             ContentView()
         }
-        .modelContainer(for: [Group.self, Member.self, Expense.self])
+        .modelContainer(for: [Group.self, Member.self, Expense.self, Settlement.self])
     }
 }

--- a/FairSplitTests/ExpenseEditingTests.swift
+++ b/FairSplitTests/ExpenseEditingTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct ExpenseEditingTests {
     @Test
     func updateExpense_changesFields() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")
@@ -28,7 +28,7 @@ struct ExpenseEditingTests {
 
     @Test
     func deleteExpense_removesFromGroup() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")
@@ -45,7 +45,7 @@ struct ExpenseEditingTests {
 
     @Test
     func addExpense_savesCategoryAndNote() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")

--- a/FairSplitTests/FxRateMemoryTests.swift
+++ b/FairSplitTests/FxRateMemoryTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct FxRateMemoryTests {
     @Test
     func addExpense_updatesLastRate() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")
@@ -20,7 +20,7 @@ struct FxRateMemoryTests {
 
     @Test
     func updateExpense_updatesLastRate() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")

--- a/FairSplitTests/GroupManagementTests.swift
+++ b/FairSplitTests/GroupManagementTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct GroupManagementTests {
     @Test
     func addGroup_thenUndo_removesIt() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let undo = UndoManager()
         let repo = DataRepository(context: context, undoManager: undo)

--- a/FairSplitTests/ImportExportTests.swift
+++ b/FairSplitTests/ImportExportTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct ImportExportTests {
     @Test
     func exportGroup_hasExpenseRow() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let a = Member(name: "Alex")
@@ -18,7 +18,7 @@ struct ImportExportTests {
 
     @Test
     func importCSV_addsExpense() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let a = Member(name: "Alex")

--- a/FairSplitTests/MemberManagementTests.swift
+++ b/FairSplitTests/MemberManagementTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct MemberManagementTests {
     @Test
     func deleteMember_preventRemovalWhenReferenced() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")
@@ -22,7 +22,7 @@ struct MemberManagementTests {
 
     @Test
     func deleteMember_removesWhenUnused() throws {
-        let container = try ModelContainer(for: Group.self, Member.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")

--- a/FairSplitTests/ReceiptAttachmentTests.swift
+++ b/FairSplitTests/ReceiptAttachmentTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct ReceiptAttachmentTests {
     @Test
     func addExpense_savesReceiptImageData() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")
@@ -22,7 +22,7 @@ struct ReceiptAttachmentTests {
 
     @Test
     func updateExpense_updatesReceiptImageData() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let repo = DataRepository(context: context)
         let alex = Member(name: "Alex")

--- a/FairSplitTests/UndoRedoTests.swift
+++ b/FairSplitTests/UndoRedoTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct UndoRedoTests {
     @Test
     func addExpense_thenUndo_removesIt() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let undo = UndoManager()
         let repo = DataRepository(context: context, undoManager: undo)
@@ -22,7 +22,7 @@ struct UndoRedoTests {
 
     @Test
     func updateExpense_thenUndo_restoresFields() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let undo = UndoManager()
         let repo = DataRepository(context: context, undoManager: undo)
@@ -41,7 +41,7 @@ struct UndoRedoTests {
 
     @Test
     func deleteExpense_thenUndo_restoresIt() throws {
-        let container = try ModelContainer(for: Group.self, Member.self, Expense.self)
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
         let context = ModelContext(container)
         let undo = UndoManager()
         let repo = DataRepository(context: context, undoManager: undo)

--- a/plan.md
+++ b/plan.md
@@ -14,12 +14,12 @@
 - Input: ✅ Currency formatter + validation for amount
 
 ## Next Up (top first — keep ≤3)
-1. [SHARE-1] Share sheet: export a readable group summary (PDF/Markdown)
-2. [MATH-5] Per-member totals and per-category totals in group
-3. [UX-2] Haptics on key actions (add expense, settle)
+1. [DATA-3] Import/Export: CSV export for a group; CSV import for expenses (document picker)
+2. [SHARE-1] Share sheet: export a readable group summary (PDF/Markdown)
+3. [MATH-5] Per-member totals and per-category totals in group
 
 ## In Progress
-[DATA-3] Import/Export: CSV export for a group; CSV import for expenses (document picker)
+(none)
 
 ## Done
 [MVP-1] Added SwiftData and a demo group
@@ -44,6 +44,7 @@
 [CORE-8] Undo/Redo for create/edit/delete operations
 [CORE-10] Groups can be added from list; sample group seeded on first launch
 [UX-7] Removed undo/redo toolbar; new groups appear immediately
+[BUG-1] Fixed new groups not appearing by including Settlement in model container
 
 
 ## Blocked
@@ -68,6 +69,7 @@
 
 ### Delight & Design (Apple-ish touches)
 - [UX-1] Dynamic Type everywhere; ensure layouts adapt up to Extra Large sizes
+- [UX-2] Haptics on key actions (add expense, settle)
 - [UX-3] SF Symbols for categories, payer, participants, settlement arrows
 - [UX-4] TipKit/coach marks: first-run hints for Add Expense and Settle Up
 - [UX-5] Pull-to-refresh (no-op placeholder until CloudKit lands)
@@ -136,6 +138,7 @@
 - 2025-08-27: CORE-8 — Added undo/redo toolbar for data actions.
 - 2025-08-27: CORE-10 — Added group creation screen and seeded sample group on first launch.
 - 2025-08-28: UX-7 — Removed undo/redo toolbar buttons and ensured new groups appear immediately.
+- 2025-08-28: BUG-1 — Fixed missing Settlement model so new groups appear after creation.
 
 
 ## Vision


### PR DESCRIPTION
## Summary
- include `Settlement` in the app's SwiftData model container so new groups save
- update previews and tests to use containers aware of `Settlement`
- document plan and changelog for the bug fix

## Testing
- `xcodebuild -scheme FairSplit -destination 'generic/platform=iOS Simulator' build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68acbc294e0c8326ace77e08f481da92