### PR TITLE
BUG-2 seed sample group with locale currency

### DIFF
--- a/FairSplit/Helpers/DataRepository.swift
+++ b/FairSplit/Helpers/DataRepository.swift
@@ -16,8 +16,9 @@ final class DataRepository {
             let alex = Member(name: "Alex")
             let sam = Member(name: "Sam")
             let kai = Member(name: "Kai")
-            let group = Group(name: "Sample Trip", defaultCurrency: "USD", members: [alex, sam, kai])
-            let e1 = Expense(title: "Groceries", amount: 36.50, currencyCode: group.defaultCurrency, payer: alex, participants: [alex, sam, kai], category: .food, note: "Milk & eggs")
+            let code = Locale.current.currency?.identifier ?? "USD"
+            let group = Group(name: "Sample Trip", defaultCurrency: code, members: [alex, sam, kai])
+            let e1 = Expense(title: "Groceries", amount: 36.50, currencyCode: code, payer: alex, participants: [alex, sam, kai], category: .food, note: "Milk & eggs")
             group.expenses.append(e1)
             context.insert(group)
             try? context.save()

--- a/FairSplitTests/SeedDataTests.swift
+++ b/FairSplitTests/SeedDataTests.swift
@@ -1,0 +1,17 @@
+import SwiftData
+import Testing
+@testable import FairSplit
+
+struct SeedDataTests {
+    @Test
+    func seedIfNeeded_createsSampleGroupWithLocaleCurrency() throws {
+        let container = try ModelContainer(for: Group.self, Member.self, Expense.self, Settlement.self)
+        let context = ModelContext(container)
+        let repo = DataRepository(context: context)
+        repo.seedIfNeeded()
+        let fetch = FetchDescriptor<Group>()
+        let groups = try context.fetch(fetch)
+        #expect(groups.count == 1)
+        #expect(groups.first?.defaultCurrency == Locale.current.currency?.identifier ?? "USD")
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -45,6 +45,7 @@
 [CORE-10] Groups can be added from list; sample group seeded on first launch
 [UX-7] Removed undo/redo toolbar; new groups appear immediately
 [BUG-1] Fixed new groups not appearing by including Settlement in model container
+[BUG-2] Seeded sample group with locale currency to ensure new groups appear
 
 
 ## Blocked
@@ -139,6 +140,7 @@
 - 2025-08-27: CORE-10 — Added group creation screen and seeded sample group on first launch.
 - 2025-08-28: UX-7 — Removed undo/redo toolbar buttons and ensured new groups appear immediately.
 - 2025-08-28: BUG-1 — Fixed missing Settlement model so new groups appear after creation.
+- 2025-08-29: BUG-2 — Seeded sample group using locale currency to ensure INR groups show.
 
 
 ## Vision


### PR DESCRIPTION
## Summary
- seed demo group using device locale so INR groups show
- add test covering seedIfNeeded with locale currency

## Testing
- `xcodebuild -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO -maximum-parallel-testing-workers 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acbe7280b08326a09ec1cea092c820