### PR TITLE
BUG-3 refresh groups list after adding

### DIFF
--- a/FairSplit/Views/GroupListView.swift
+++ b/FairSplit/Views/GroupListView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import SwiftData
 
 struct GroupListView: View {
-    @Query private var groups: [Group]
+    @Query(sort: [SortDescriptor(\Group.name)]) private var groups: [Group]
     @Environment(\.modelContext) private var modelContext
     @Environment(\.undoManager) private var undoManager
     @State private var searchText = ""
@@ -48,7 +48,10 @@ struct GroupListView: View {
         }
         .sheet(isPresented: $showingAdd) {
             AddGroupView { name, currency in
-                DataRepository(context: modelContext, undoManager: undoManager).addGroup(name: name, defaultCurrency: currency)
+                withAnimation {
+                    DataRepository(context: modelContext, undoManager: undoManager)
+                        .addGroup(name: name, defaultCurrency: currency)
+                }
                 searchText = ""
             }
         }

--- a/plan.md
+++ b/plan.md
@@ -46,6 +46,7 @@
 [UX-7] Removed undo/redo toolbar; new groups appear immediately
 [BUG-1] Fixed new groups not appearing by including Settlement in model container
 [BUG-2] Seeded sample group with locale currency to ensure new groups appear
+[BUG-3] Ensure groups list refreshes when adding a new group
 
 
 ## Blocked
@@ -141,6 +142,7 @@
 - 2025-08-28: UX-7 — Removed undo/redo toolbar buttons and ensured new groups appear immediately.
 - 2025-08-28: BUG-1 — Fixed missing Settlement model so new groups appear after creation.
 - 2025-08-29: BUG-2 — Seeded sample group using locale currency to ensure INR groups show.
+- 2025-08-30: BUG-3 — Fixed groups list not updating after adding a group.
 
 
 ## Vision


### PR DESCRIPTION
## Summary
- ensure group query sorts consistently
- animate group insertion so the list refreshes immediately
- document bug fix in plan

## Testing
- `xcodebuild -scheme FairSplit -destination 'generic/platform=iOS Simulator' build` *(fails: command not found)*
- `xcodebuild test -scheme FairSplit -destination 'platform=iOS Simulator,name=iPhone 16'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc2dba07c8326be7ca91b31dd64de